### PR TITLE
Improve behaviour when entering/correcting OH text directly

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
        # Needed to get some information about the pull request, if any
@@ -20,15 +20,22 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: set up JDK 17
       uses: actions/setup-java@v1
       with:
         java-version: 17
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
     - name: run tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 28
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
         script: ./gradlew connectedCheck
     - name: Upload Test Results
       if: ${{ always() }}

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="No">No</string>
     <string name="Start">Start</string>
     <string name="End">End</string>
+    <string name="spd_ohf_update_hint">Press enter to update form</string>
 
     <string name="default_hint">Opening hours string</string>
 


### PR DESCRIPTION
This adds back a TextWatcher to the EditText but doesn't rebuild the form instead it shows parse errors or a text indicating that enter needs to pressed to update the form display.

Resolves https://github.com/simonpoole/OpeningHoursFragment/issues/60